### PR TITLE
Optimize release settings for size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,7 +76,7 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "tiny-health-checker"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "ureq",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,8 @@ anyhow = "1.0"
 [dependencies.ureq]
 version = "2.4"
 default-features = false
+
+[profile.release]
+opt-level = "s"
+lto = "fat"
+strip = "symbols"


### PR DESCRIPTION
Reduce the binary size by stripping symbols, enabling LTO and using optimization level 's'. This brought the binary size on Linux down from about 4.8M to just under 1M.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>